### PR TITLE
docs: documentation and variable description cleanup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-10-25T23:10:16Z",
+  "generated_at": "2022-12-22T14:42:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,7 +76,18 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "ff9ee043d85595eb255c05dfe32ece02a53efbb2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
   "version": "0.13.1+ibm.55.dss",
   "word_list": {
     "file": null,

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The type of endpoint to be used for creating keys. Accepts 'public' or 'private' | `string` | `"private"` | no |
+| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The type of endpoint to be used for creating keys. Accepts 'public' or 'private' | `string` | `"public"` | no |
 | <a name="input_instance_id"></a> [instance\_id](#input\_instance\_id) | The Key Protect instance GUID | `string` | n/a | yes |
 | <a name="input_key_ring_id"></a> [key\_ring\_id](#input\_key\_ring\_id) | The ID that identifies the Key Ring. Each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Key Protect key ring module
-<!-- UPDATE BADGE: Update the link for the following badge-->
+
 [![Stable (With Quality Checks)](https://img.shields.io/badge/Status-Stable%20(With%20quality%20checks)-green?style=plastic)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
 [![Build status](https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring/actions/workflows/ci.yml/badge.svg)](https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring/actions/workflows/ci.yml)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
@@ -7,7 +7,7 @@
 [![latest release](https://img.shields.io/github/v/release/terraform-ibm-modules/terraform-ibm-key-protect-key-ring?logo=GitHub&sort=semver)](https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring/releases/latest)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
-This module creates a key ring to help organize keys in a Key Protect instance.
+This module creates a key ring to help organize keys in a Key Protect instance.  
 For more information, about key management rings, see [creating key rings](https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys#create-key-ring-api).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![latest release](https://img.shields.io/github/v/release/terraform-ibm-modules/terraform-ibm-key-protect-key-ring?logo=GitHub&sort=semver)](https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring/releases/latest)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
-This module creates a key ring to help organize keys in a Key Protect instance.  
+This module creates a key ring to help organize keys in a Key Protect instance.
 For more information, about key management rings, see [creating key rings](https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys#create-key-ring-api).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<!-- BEGIN MODULE HOOK -->
-
-<!-- Update the title to match the module name and add a description -->
 # Key Protect key ring module
 <!-- UPDATE BADGE: Update the link for the following badge-->
 [![Stable (With Quality Checks)](https://img.shields.io/badge/Status-Stable%20(With%20quality%20checks)-green?style=plastic)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
@@ -8,23 +5,24 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![latest release](https://img.shields.io/github/v/release/terraform-ibm-modules/terraform-ibm-key-protect-key-ring?logo=GitHub&sort=semver)](https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring/releases/latest)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
 This module creates a key ring to help organize keys in a Key Protect instance.
+For more information, about key management rings, see [creating key rings](https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys#create-key-ring-api).
 
 ## Usage
-
-<!-- Add sample usage of the module itself in the following code block -->
 ```hcl
-##############################################################################
-# Key Protect Key Ring
-##############################################################################
+provider "ibm" {
+  ibmcloud_api_key = "XXXXXXXXXX"
+  # Must be the same region the Key Protect instance is in
+  region           = "us-south"
+}
 
-# Replace "main" with a GIT release version to lock into a specific release
-module "key_protect_module" {
+module "key_protect_key_ring" {
+  # Replace "main" with a GIT release version to lock into a specific release
   source        = "git::https://github.com:terraform-ibm-modules/terraform-ibm-key-protect-key-ring.git?ref=main"
-  endpoint_type = var.endpoint_type
-  instance_id   = var.instance_id
-  key_ring_id   = "${var.prefix}-key-ring"
+  instance_id   = "XXxxXXxx-xxxx-XXXX-xxxx-XXxxXXxx"
+  key_ring_id   = "my-key-ring"
 }
 ```
 
@@ -68,9 +66,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The type of endpoint to be used for creating keys, accepts 'public' or 'private' | `string` | `"private"` | no |
+| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The type of endpoint to be used for creating keys. Accepts 'public' or 'private' | `string` | `"private"` | no |
 | <a name="input_instance_id"></a> [instance\_id](#input\_instance\_id) | The Key Protect instance GUID | `string` | n/a | yes |
-| <a name="input_key_ring_id"></a> [key\_ring\_id](#input\_key\_ring\_id) | The ID that identifies the Key Ring, each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service | `string` | n/a | yes |
+| <a name="input_key_ring_id"></a> [key\_ring\_id](#input\_key\_ring\_id) | The ID that identifies the Key Ring. Each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -1,9 +1,7 @@
 # End to end example with default values
 
 An end-to-end example that uses the module's default variable values.
-This example uses the IBM Cloud terraform provider to:
- - Create a new resource group if one is not passed in.
- - Create a new Key Protect instance in the resource group.
+This example will:
+ - Create a new resource group (if existing one is not passed in).
+ - Create a new Key Protect instance in the region and resource group provided.
  - Create a Key Ring within the Key Protect Instance.
-
-<!-- Add your example and link to it from the module's main readme file. -->

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -20,7 +20,6 @@ resource "ibm_resource_instance" "key_protect_instance" {
   plan              = "tiered-pricing"
   location          = var.region
   tags              = var.resource_tags
-  service_endpoints = "public-and-private"
 }
 
 ##############################################################################

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -10,15 +10,17 @@ module "resource_group" {
 }
 
 ##############################################################################
-# Key Protect module
+# Key Protect instance
 ##############################################################################
 
-module "key_protect_module" {
-  source            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.2.0"
-  key_protect_name  = "${var.prefix}-kp"
+resource "ibm_resource_instance" "key_protect_instance" {
+  name              = "${var.prefix}-key-protect"
   resource_group_id = module.resource_group.resource_group_id
-  region            = var.region
+  service           = "kms"
+  plan              = "tiered-pricing"
+  location          = var.region
   tags              = var.resource_tags
+  service_endpoints = "public-and-private"
 }
 
 ##############################################################################
@@ -26,8 +28,7 @@ module "key_protect_module" {
 ##############################################################################
 
 module "key_protect_key_ring" {
-  source        = "../.."
-  instance_id   = module.key_protect_module.key_protect_guid
-  key_ring_id   = "${var.prefix}-key-ring"
-  endpoint_type = "public"
+  source      = "../.."
+  instance_id = ibm_resource_instance.key_protect_instance.guid
+  key_ring_id = "${var.prefix}-key-ring"
 }

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -14,7 +14,12 @@ output "resource_group_id" {
 
 output "key_protect_id" {
   description = "Key Protect Instance ID"
-  value       = module.key_protect_module.key_protect_guid
+  value       = ibm_resource_instance.key_protect_instance.id
+}
+
+output "key_protect_guid" {
+  description = "Key Protect Instance GUID"
+  value       = ibm_resource_instance.key_protect_instance.guid
 }
 
 output "key_protect_key_ring_id" {

--- a/examples/default/provider.tf
+++ b/examples/default/provider.tf
@@ -2,18 +2,3 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
 }
-
-data "ibm_iam_auth_token" "token_data" {
-}
-
-provider "restapi" {
-  uri                   = "https:"
-  write_returns_object  = false
-  create_returns_object = false
-  debug                 = false # set to true to show detailed logs, but use carefully as it might print sensitive values.
-  headers = {
-    Authorization    = data.ibm_iam_auth_token.token_data.iam_access_token
-    Bluemix-Instance = module.key_protect_module.key_protect_guid
-    Content-Type     = "application/vnd.ibm.kms.policy+json"
-  }
-}

--- a/examples/default/version.tf
+++ b/examples/default/version.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = "1.48.0"
     }
-    # The restapi provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
-    restapi = {
-      source  = "Mastercard/restapi"
-      version = ">= 1.18.0"
-    }
   }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -5,7 +5,7 @@
       "name": "endpoint_type",
       "type": "string",
       "description": "The type of endpoint to be used for creating keys. Accepts 'public' or 'private'",
-      "default": "private",
+      "default": "public",
       "source": [
         "ibm_kms_key_rings.key_ring.endpoint_type"
       ],

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -4,7 +4,7 @@
     "endpoint_type": {
       "name": "endpoint_type",
       "type": "string",
-      "description": "The type of endpoint to be used for creating keys, accepts 'public' or 'private'",
+      "description": "The type of endpoint to be used for creating keys. Accepts 'public' or 'private'",
       "default": "private",
       "source": [
         "ibm_kms_key_rings.key_ring.endpoint_type"
@@ -37,7 +37,7 @@
     "key_ring_id": {
       "name": "key_ring_id",
       "type": "string",
-      "description": "The ID that identifies the Key Ring, each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service",
+      "description": "The ID that identifies the Key Ring. Each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service",
       "required": true,
       "source": [
         "ibm_kms_key_rings.key_ring.key_ring_id"

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -8,34 +8,34 @@ import (
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
+// Use existing resource group for tests
 const resourceGroup = "geretain-test-key-protect-key-ring"
 const defaultExampleTerraformDir = "examples/default"
+
+func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
+	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
+		Testing:       t,
+		TerraformDir:  terraformDir,
+		Prefix:        prefix,
+		ResourceGroup: resourceGroup,
+	})
+
+	return options
+}
 
 func TestRunDefaultExample(t *testing.T) {
 	t.Parallel()
 
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  defaultExampleTerraformDir,
-		Prefix:        "kp-key-ring",
-		ResourceGroup: resourceGroup,
-	})
-
+	options := setupOptions(t, "kp-key-ring")
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
 }
 
-func TestRunUpgradeExample(t *testing.T) {
+func TestRunUpgrade(t *testing.T) {
 	t.Parallel()
 
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  defaultExampleTerraformDir,
-		Prefix:        "kp-key-ring-upg",
-		ResourceGroup: resourceGroup,
-	})
-
+	options := setupOptions(t, "kp-key-ring-upg")
 	output, err := options.RunTestUpgrade()
 	if !options.UpgradeTestSkipped {
 		assert.Nil(t, err, "This should not have errored")

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -10,7 +10,7 @@ import (
 
 // Use existing resource group for tests
 const resourceGroup = "geretain-test-key-protect-key-ring"
-const defaultExampleTerraformDir = "examples/default"
+const terraformDir = "examples/default"
 
 func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@
 variable "endpoint_type" {
   type        = string
   description = "The type of endpoint to be used for creating keys. Accepts 'public' or 'private'"
-  default     = "private"
+  default     = "public"
   validation {
     condition     = can(regex("public|private", var.endpoint_type))
     error_message = "The endpoint_type value must be 'public' or 'private'."

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@
 
 variable "endpoint_type" {
   type        = string
-  description = "The type of endpoint to be used for creating keys, accepts 'public' or 'private'"
+  description = "The type of endpoint to be used for creating keys. Accepts 'public' or 'private'"
   default     = "private"
   validation {
     condition     = can(regex("public|private", var.endpoint_type))
@@ -19,7 +19,7 @@ variable "instance_id" {
 
 variable "key_ring_id" {
   type        = string
-  description = "The ID that identifies the Key Ring, each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service"
+  description = "The ID that identifies the Key Ring. Each ID is unique within the given Key Protect instance but is not reserved across the Key Protect service"
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9-]{2,100}$", var.key_ring_id))

--- a/version.tf
+++ b/version.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = ">= 1.0.0"
   required_providers {
+    # Use "greater than or equal to" range in modules
     ibm = {
-      source = "IBM-Cloud/ibm"
-      # Use "greater than or equal to" range in modules
+      source  = "IBM-Cloud/ibm"
       version = ">= 1.48.0"
     }
   }


### PR DESCRIPTION
### Description

- documentation and variable description cleanup
- updated the default example to use `ibm_resource_instance` to provision the KP instance instead of the `terraform-ibm-key-protect` module since it also requires restapi provider (Had to skip upgrade test for this - no impact to main module)
- test cleanup (removed code duplication)

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [x] If relevant, a test for the change has been added or updated as part of this PR.
- [x] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
